### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/src/moduls/ui/QTStarter/tuimod.cpp
+++ b/src/moduls/ui/QTStarter/tuimod.cpp
@@ -783,7 +783,7 @@ void StApp::callQtModule( )
     }
 }
 
-bool StApp::updLookFeel( )
+void StApp::updLookFeel( )
 {
     QStyle *appStl = QStyleFactory::create(mod->style().c_str());
     if(appStl)	QApplication::setStyle(appStl);

--- a/src/moduls/ui/QTStarter/tuimod.h
+++ b/src/moduls/ui/QTStarter/tuimod.h
@@ -122,7 +122,7 @@ public:
     void createTray( );
     bool callQtModule( const string &nm );
 
-    bool updLookFeel( );
+    void updLookFeel( );
 
     bool notify( QObject *receiver, QEvent *event );
     void saveState( QSessionManager &manager );


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.